### PR TITLE
windows-2022 is too slow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-18.04, windows-2022, windows-2019, macos-11, macos-10.15 ]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
`windows-2022` timed out frequently.